### PR TITLE
fix inherited relationships

### DIFF
--- a/src/SubtypeModel.php
+++ b/src/SubtypeModel.php
@@ -736,6 +736,52 @@ abstract class SubtypeModel extends Model
     }
 
     /**
+     * Determine if the given key is a relationship method.
+     *
+     * Extends Eloquent's check so that relationship methods declared on the
+     * CTI parent class resolve as relations on the subtype. This makes
+     * dynamic property access (e.g. $quiz->tags) work alongside the existing
+     * method-call proxy in __call().
+     *
+     * @param string $key
+     * @return bool
+     */
+    public function isRelation($key)
+    {
+        // Subtype attribute mutator must win over a parent relation of the same name.
+        if ($this->hasAttributeMutator($key)) {
+            return false;
+        }
+
+        if (parent::isRelation($key)) {
+            return true;
+        }
+
+        $parentClass = $this->getCtiParentClass();
+        if (!$parentClass || !class_exists($parentClass)) {
+            return false;
+        }
+
+        if (!method_exists($parentClass, $key)) {
+            return false;
+        }
+
+        // Ignore methods inherited from Eloquent's base Model — they're not relations.
+        if (method_exists(Model::class, $key)) {
+            return false;
+        }
+
+        // Ignore methods provided by CTI traits used by the parent.
+        foreach (class_uses_recursive($parentClass) as $trait) {
+            if (str_starts_with($trait, 'Pannella\\Cti\\') && method_exists($trait, $key)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
      * Handle dynamic method calls to proxy parent model relationships.
      * If the method doesn't exist on this model but exists on the parent CTI class,
      * proxy the call to the parent model to access parent relationships.

--- a/tests/Unit/SubtypeModelTest.php
+++ b/tests/Unit/SubtypeModelTest.php
@@ -1856,6 +1856,79 @@ class SubtypeModelTest extends TestCase
     }
 
     /**
+     * Test that parent relationships are accessible from subtype instances as
+     * dynamic properties (e.g. $quiz->tags), not just as method calls.
+     */
+    public function testParentRelationshipAccessibleFromSubtypeAsDynamicProperty(): void
+    {
+        $this->createQuizRecord(
+            ['id' => 1, 'title' => 'Quiz with tags', 'type_id' => 1],
+            ['assessment_id' => 1, 'passing_score' => 85]
+        );
+
+        DB::table('assessment_tag')->insert([
+            ['assessment_id' => 1, 'tag_name' => 'math'],
+            ['assessment_id' => 1, 'tag_name' => 'algebra'],
+        ]);
+
+        $quiz = Quiz::find(1);
+        $this->assertNotNull($quiz);
+
+        // Access parent relationship as dynamic property
+        $tags = $quiz->tags;
+
+        $this->assertNotNull($tags);
+        $this->assertCount(2, $tags);
+        $this->assertEquals('math', $tags[0]->tag_name);
+        $this->assertEquals('algebra', $tags[1]->tag_name);
+
+        // Subsequent accesses should return the cached/loaded relation
+        $this->assertTrue($quiz->relationLoaded('tags'));
+        $this->assertSame($tags, $quiz->tags);
+    }
+
+    /**
+     * Test that parent relationships are eager-loadable from subtype instances.
+     */
+    public function testParentRelationshipEagerLoadableFromSubtype(): void
+    {
+        $this->createQuizRecord(
+            ['id' => 1, 'title' => 'Quiz with tags', 'type_id' => 1],
+            ['assessment_id' => 1, 'passing_score' => 85]
+        );
+
+        DB::table('assessment_tag')->insert([
+            ['assessment_id' => 1, 'tag_name' => 'math'],
+            ['assessment_id' => 1, 'tag_name' => 'algebra'],
+        ]);
+
+        $quiz = Quiz::with('tags')->find(1);
+
+        $this->assertTrue($quiz->relationLoaded('tags'));
+        $this->assertCount(2, $quiz->tags);
+    }
+
+    /**
+     * Accessing a CTI infrastructure helper as a dynamic property must not be
+     * mistaken for a relationship. Pre-fix this returned null, so the override
+     * must preserve that behavior — not throw Eloquent's relationship LogicException.
+     */
+    public function testCtiInfrastructureMethodNotTreatedAsRelation(): void
+    {
+        $this->createQuizRecord(
+            ['id' => 1, 'title' => 'Quiz', 'type_id' => 1],
+            ['assessment_id' => 1, 'passing_score' => 85]
+        );
+
+        $quiz = Quiz::find(1);
+
+        // getSubtypeKey is declared on the HasSubtypes trait used by Assessment.
+        // It returns a string, not a Relation, so treating it as a relation would
+        // throw a LogicException from Eloquent's getRelationshipFromMethod().
+        $this->assertNull($quiz->getSubtypeKey);
+    }
+
+    /**
      * Test that parent relationship queries work correctly.
      * Should be able to query parent relationships with where clauses, etc.
      */


### PR DESCRIPTION
 - override isRelation() on the subtype model to return true for methods declared on the parent cti class
 - exclude inherited framework methods and cti package methods
 - added regression test

fixes #20 