### PR TITLE
fix: create subtype row on insert even when subtype attributes are clean

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "orm",
         "multi-table"
     ],
-    "version": "3.5.0",
+    "version": "3.5.2",
     "authors": [
         {
             "name": "Matt Pannella",

--- a/src/SubtypeModel.php
+++ b/src/SubtypeModel.php
@@ -145,6 +145,9 @@ abstract class SubtypeModel extends Model
             $originalAttributesArray = $this->attributes;
             $dirtyAttributes = $this->getDirty();
 
+            //capture pre-save existence so we can force a subtype write on insert
+            $wasExisting = $this->exists;
+
             //split dirty attributes
             $dirtyParentAttributes = array_intersect_key(
                 $dirtyAttributes,
@@ -171,8 +174,9 @@ abstract class SubtypeModel extends Model
                     $postSaveParentAttributes
                 );
 
-                //save subtype data if we have any
-                if (!empty($dirtySubtypeAttributes)) {
+                //save subtype data if we have dirty subtype attributes,
+                //or always on insert so a subtype row exists even when pristine
+                if (!empty($dirtySubtypeAttributes) || !$wasExisting) {
                     $this->saveSubtypeData();
                 }
 

--- a/tests/Unit/SubtypeModelTest.php
+++ b/tests/Unit/SubtypeModelTest.php
@@ -221,6 +221,32 @@ class SubtypeModelTest extends TestCase
     }
 
     /**
+     * Regression: a subtype created with no dirty subtype attributes (all columns
+     * left at their defaults) must still persist a subtype row, not just the parent.
+     */
+    public function testCreateSurveyWithPristineSubtypeAttributes(): void
+    {
+        $survey = new Survey();
+
+        // No subtype attributes are explicitly set — anonymous/allow_multiple_responses
+        // keep their defaults, so getDirty() yields no dirty subtype attributes.
+        $saved = $survey->save();
+
+        $this->assertTrue($saved);
+
+        $assessment = DB::table('assessment')->first();
+        $this->assertNotNull($assessment);
+        $this->assertEquals(2, $assessment->type_id);
+
+        $surveyData = DB::table('assessment_survey')
+            ->where('assessment_id', $assessment->id)
+            ->first();
+        $this->assertNotNull($surveyData, 'Subtype row should be created even when pristine');
+        $this->assertEquals(0, $surveyData->anonymous);
+        $this->assertEquals(0, $surveyData->allow_multiple_responses);
+    }
+
+    /**
      * Test creating a new quiz automatically sets the correct type_id
      */
     public function testCreateNewQuiz(): void


### PR DESCRIPTION
resolves #22 